### PR TITLE
Arp step length

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -13,6 +13,14 @@ DEFAULT_ROOT_NOTES = ["E4", "A4", "D4", "G4"]
 DEFAULT_MODE = 'minor'
 MODE_CHOICES = ['major', 'minor', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'locrian']
 DEFAULT_ARP_STEPS = 8
+
+# Define step choices with musical note lengths
+ARP_STEP_CHOICES = [
+    questionary.Choice("16 steps (16th notes)", value=16),
+    questionary.Choice("8 steps (8th notes)", value=8),
+    questionary.Choice("4 steps (quarter notes)", value=4)
+]
+
 DEFAULT_MIN_OCTAVE = 3
 DEFAULT_MAX_OCTAVE = 5
 DEFAULT_BPM = 120
@@ -45,7 +53,6 @@ DEFAULT_DRONE_OCTAVE_DOUBLING_CHANCE = 0.25 # Chance to double a note an octave 
 DEFAULT_DRONE_ALLOW_OCTAVE_SHIFTS = True # Allow notes to shift octave during variation
 DEFAULT_DRONE_ENABLE_WALKDOWNS = True # Enable melodic walkdowns to doubled notes
 DEFAULT_DRONE_WALKDOWN_NUM_STEPS = 2 # Number of steps in the walkdown
-# DEFAULT_DRONE_WALKDOWN_STEP_TICKS = 120 # Duration of each walkdown step in MIDI ticks (120 = 16th note at 480 TPQN)
 
 # New selectable choices for walkdown step duration
 TICKS_PER_QUARTER_NOTE = 480
@@ -130,7 +137,14 @@ if __name__ == "__main__":
 
     if generation_type == 'arpeggio':
         print("\n--- Arpeggio Specific Settings ---")
-        arp_steps = int(questionary.text("Number of steps per arpeggio cycle:", default=str(DEFAULT_ARP_STEPS)).ask() or DEFAULT_ARP_STEPS)
+        print("Choose how many steps in your arpeggio cycle.")
+        print("Fewer steps = longer notes. The pattern will fill the entire bar.")
+        arp_steps = questionary.select(
+            "Steps per arpeggio cycle:",
+            choices=ARP_STEP_CHOICES,
+            default=8
+        ).ask()
+        
         arp_mode = questionary.select("Arpeggiator mode:", choices=ARP_MODE_CHOICES, default=DEFAULT_ARP_MODE).ask()
         range_octaves = int(questionary.text("Arpeggio range in octaves (from min_octave):", default=str(DEFAULT_RANGE_OCTAVES)).ask() or DEFAULT_RANGE_OCTAVES)
         evolution_rate = float(questionary.text("Arpeggio evolution rate (0.0 to 1.0):", default=str(DEFAULT_EVOLUTION_RATE)).ask() or DEFAULT_EVOLUTION_RATE)

--- a/arpeggio_generation.py
+++ b/arpeggio_generation.py
@@ -3,7 +3,7 @@ from .notes import note_str_to_midi, note_to_name
 from .arpeggio import create_arpeggio
 from .drone_generation import generate_drone_events 
 from .midi import create_midi_file
-from typing import Dict, List, Optional # Optional might be needed for arpeggio list
+from typing import Dict, List, Optional, Tuple
 from .effects import EffectRegistry
 from .effects_base import MidiEffect
 
@@ -13,9 +13,8 @@ def create_arp(options: Dict):
     """
     root = options.get('root', 0)
     root_notes_str_param = options.get('root_notes', None)
-    generation_type = options.get('generation_type', 'arpeggio') # Get generation type
+    generation_type = options.get('generation_type', 'arpeggio')
     
-    # Optional: Keep debug prints for now, can be removed later
     print(f"[DEBUG] Generation Type: {generation_type}")
     print(f"[DEBUG] root_notes_str_param from options: {root_notes_str_param}")
 
@@ -34,8 +33,8 @@ def create_arp(options: Dict):
     max_octave = options.get('max_octave', 6)
     use_chord_tones = options.get('use_chord_tones', True)
     
-    # Arpeggio-specific options (might be ignored by drone generation initially)
-    arp_steps = options.get('arp_steps', 8) # Default was 16, changed to 8 based on __main__.py
+    # Arpeggio-specific options
+    arp_steps = options.get('arp_steps', 8)
     arp_mode = options.get('arp_mode', 'up')
     range_octaves = options.get('range_octaves', 1)
     evolution_rate = options.get('evolution_rate', 0.1)
@@ -46,6 +45,8 @@ def create_arp(options: Dict):
     effects_config = options.get('effects_config', [])
     
     print("\n[DEBUG] Creating effects:")
+    
+    # Add other effects
     for effect_conf in effects_config:
         effect_name = effect_conf.get('name', '')
         print(f"[DEBUG] Processing effect: {effect_name}")
@@ -57,16 +58,28 @@ def create_arp(options: Dict):
         else:
             print(f"[WARNING] Failed to create effect: {effect_name}")
 
-    # This will hold the final list of events to be passed to create_midi_file
-    # For arpeggios: List[Optional[int]] (flat list of 16th note steps)
-    # For drones: List[Tuple[note, start_tick, duration_tick, velocity]] (structured events)
-    final_event_list: List = [] 
+    # This will hold our flat list of notes
+    final_event_list: List[Optional[int]] = []
 
     if generation_type == 'arpeggio':
-        # Logic for generating flat list of arpeggio notes (16th steps)
-        flat_arpeggio_notes: List[Optional[int]] = []
+        # Each bar has 16 16th notes
+        steps_per_bar = 16
+        ticks_per_beat = 480  # Standard MIDI ticks per quarter note
+        ticks_per_16th = ticks_per_beat // 4
+        
+        # Calculate note length based on number of steps
+        # If arp_steps = 16, each note is a 16th note (1 step)
+        # If arp_steps = 8, each note is an 8th note (2 steps)
+        # If arp_steps = 4, each note is a quarter note (4 steps)
+        steps_per_note = steps_per_bar // arp_steps
+        
+        print(f"[DEBUG] Steps per bar: {steps_per_bar}")
+        print(f"[DEBUG] Arp steps: {arp_steps}")
+        print(f"[DEBUG] Steps per note: {steps_per_note}")
+        
         if processed_root_notes_midi:
             bars_per_segment = bars // len(processed_root_notes_midi) if len(processed_root_notes_midi) > 0 else bars
+            
             for idx, current_root_midi in enumerate(processed_root_notes_midi):
                 num_bars_for_segment = bars_per_segment
                 if idx == len(processed_root_notes_midi) - 1:
@@ -80,42 +93,36 @@ def create_arp(options: Dict):
                     evolution_rate=evolution_rate, repetition_factor=repetition_factor
                 )
                 
+                if not arpeggio_cycle_pattern:
+                    continue
+                    
+                # For each bar in this segment
                 for _ in range(num_bars_for_segment):
-                    # Tile the arpeggio_cycle_pattern to fill 16 steps for the current bar
-                    full_bar_steps = 16 
-                    if not arpeggio_cycle_pattern: continue # Safety
-                    # Ensure len(arpeggio_cycle_pattern) is not zero before division/modulo
-                    if len(arpeggio_cycle_pattern) == 0: continue 
-                    num_repeats = full_bar_steps // len(arpeggio_cycle_pattern)
-                    remainder_steps = full_bar_steps % len(arpeggio_cycle_pattern)
-                    for _ in range(num_repeats):
-                        flat_arpeggio_notes.extend(arpeggio_cycle_pattern)
-                    flat_arpeggio_notes.extend(arpeggio_cycle_pattern[:remainder_steps])
-        else: # Fallback if no root notes somehow (should be caught earlier)
-            pass # Or generate a default single root arpeggio
-        
-        # Ensure total length matches bars * 16 steps
-        total_expected_steps = bars * 16
-        if len(flat_arpeggio_notes) > total_expected_steps:
-            final_event_list = flat_arpeggio_notes[:total_expected_steps]
-        elif len(flat_arpeggio_notes) < total_expected_steps:
-            # Pad with rests (None) if too short
-            final_event_list = flat_arpeggio_notes + [None] * (total_expected_steps - len(flat_arpeggio_notes))
-        else:
-            final_event_list = flat_arpeggio_notes
+                    # For each note in the pattern
+                    for note in arpeggio_cycle_pattern:
+                        # Add the note followed by None values to create the proper length
+                        final_event_list.append(note)  # The note itself
+                        final_event_list.extend([None] * (steps_per_note - 1))  # Fill remaining steps with None
+
+        # Ensure total length matches bars * steps_per_bar
+        total_expected_steps = bars * steps_per_bar
+        if len(final_event_list) > total_expected_steps:
+            final_event_list = final_event_list[:total_expected_steps]
+        elif len(final_event_list) < total_expected_steps:
+            # Pad with None if too short
+            final_event_list.extend([None] * (total_expected_steps - len(final_event_list)))
 
     elif generation_type == 'drone':
         # Call drone generation function
         # This function must return List[Tuple[note, start_tick, duration_tick, velocity]]
         # Pass relevant options and the processed MIDI root notes
-        drone_options = options.copy() # Pass a copy to avoid modification issues if any
+        drone_options = options.copy()
         final_event_list = generate_drone_events(drone_options, processed_root_notes_midi)
         print(f"[INFO] Drone generation selected. {len(final_event_list)} drone events generated.")
 
     # --- Filename and MIDI file creation --- 
-    # (This part is largely the same, uses final_event_list)
     root_notes_names_for_file = '-'.join([note_to_name(note) for note in processed_root_notes_midi]) if processed_root_notes_midi else str(root)
-    base_filename = f"{generation_type}_{mode}_{root_notes_names_for_file}" # Include generation_type in filename
+    base_filename = f"{generation_type}_{mode}_{root_notes_names_for_file}"
     
     output_folder = "generated"
     current_script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/rest_patterns/__init__.py
+++ b/rest_patterns/__init__.py
@@ -1,0 +1,49 @@
+"""
+Rest pattern generation module for MIDI sequences.
+"""
+
+from .types import (
+    RestPatternType,
+    RestPattern,
+    Tick,
+    Step,
+    TICKS_PER_QUARTER,
+    STEPS_PER_BAR,
+    MIN_PATTERN_LENGTH,
+    MAX_PATTERN_LENGTH,
+    DEFAULT_REST_ENABLED,
+    DEFAULT_PATTERN_TYPE,
+    DEFAULT_MAINTAIN_RHYTHM
+)
+
+from .rest_config import (
+    BaseRestConfig,
+    FixedPatternConfig,
+    ProbabilityConfig,
+    MusicalPosConfig,
+    PhraseConfig,
+    RestPatternConfig
+)
+
+__all__ = [
+    # Types and constants
+    'RestPatternType',
+    'RestPattern',
+    'Tick',
+    'Step',
+    'TICKS_PER_QUARTER',
+    'STEPS_PER_BAR',
+    'MIN_PATTERN_LENGTH',
+    'MAX_PATTERN_LENGTH',
+    'DEFAULT_REST_ENABLED',
+    'DEFAULT_PATTERN_TYPE',
+    'DEFAULT_MAINTAIN_RHYTHM',
+    
+    # Configuration classes
+    'BaseRestConfig',
+    'FixedPatternConfig',
+    'ProbabilityConfig',
+    'MusicalPosConfig',
+    'PhraseConfig',
+    'RestPatternConfig'
+] 

--- a/rest_patterns/__init__.py
+++ b/rest_patterns/__init__.py
@@ -1,49 +1,15 @@
 """
-Rest pattern generation module for MIDI sequences.
+Rest pattern generation module.
 """
 
-from .types import (
-    RestPatternType,
-    RestPattern,
-    Tick,
-    Step,
-    TICKS_PER_QUARTER,
-    STEPS_PER_BAR,
-    MIN_PATTERN_LENGTH,
-    MAX_PATTERN_LENGTH,
-    DEFAULT_REST_ENABLED,
-    DEFAULT_PATTERN_TYPE,
-    DEFAULT_MAINTAIN_RHYTHM
-)
-
-from .rest_config import (
-    BaseRestConfig,
-    FixedPatternConfig,
-    ProbabilityConfig,
-    MusicalPosConfig,
-    PhraseConfig,
-    RestPatternConfig
-)
+from .rest_config import RestPatternConfig
+from .rest_processor import RestPatternEffect, RestPatternConfiguration
+from .types import TICKS_PER_QUARTER, STEPS_PER_BAR
 
 __all__ = [
-    # Types and constants
-    'RestPatternType',
-    'RestPattern',
-    'Tick',
-    'Step',
+    'RestPatternConfig',
+    'RestPatternEffect',
+    'RestPatternConfiguration',
     'TICKS_PER_QUARTER',
-    'STEPS_PER_BAR',
-    'MIN_PATTERN_LENGTH',
-    'MAX_PATTERN_LENGTH',
-    'DEFAULT_REST_ENABLED',
-    'DEFAULT_PATTERN_TYPE',
-    'DEFAULT_MAINTAIN_RHYTHM',
-    
-    # Configuration classes
-    'BaseRestConfig',
-    'FixedPatternConfig',
-    'ProbabilityConfig',
-    'MusicalPosConfig',
-    'PhraseConfig',
-    'RestPatternConfig'
+    'STEPS_PER_BAR'
 ] 

--- a/rest_patterns/rest_config.py
+++ b/rest_patterns/rest_config.py
@@ -1,137 +1,20 @@
 """
-Configuration classes for rest pattern generation.
+Configuration for rest pattern generation.
 """
 
 from dataclasses import dataclass
-from typing import Optional, List
-from .types import RestPatternType, MIN_PATTERN_LENGTH, MAX_PATTERN_LENGTH
-
-@dataclass
-class BaseRestConfig:
-    """Base configuration for all rest patterns."""
-    enabled: bool = False
-    maintain_rhythm: bool = True  # If True, maintain original timing when inserting rests
-
-@dataclass
-class FixedPatternConfig(BaseRestConfig):
-    """Configuration for fixed-interval rest patterns."""
-    steps_between_rests: int = 4  # Insert rest every N steps
-    pattern_shift: bool = False    # Whether pattern position shifts over time
-    
-    def __post_init__(self):
-        """Validate configuration."""
-        if not MIN_PATTERN_LENGTH <= self.steps_between_rests <= MAX_PATTERN_LENGTH:
-            raise ValueError(f"steps_between_rests must be between {MIN_PATTERN_LENGTH} and {MAX_PATTERN_LENGTH}")
-
-@dataclass
-class ProbabilityConfig(BaseRestConfig):
-    """Configuration for probability-based rest patterns."""
-    rest_chance: float = 0.15     # Probability of rest per step (0-1)
-    beat_weight: float = 1.5      # How much to favor strong beats for rests
-    
-    def __post_init__(self):
-        """Validate configuration."""
-        if not 0 <= self.rest_chance <= 1:
-            raise ValueError("rest_chance must be between 0 and 1")
-        if self.beat_weight < 0:
-            raise ValueError("beat_weight must be non-negative")
-
-@dataclass
-class MusicalPosConfig(BaseRestConfig):
-    """Configuration for musical-position-based rest patterns."""
-    rest_positions: List[int] = None  # List of step positions to rest (0-15 in 16-step bar)
-    accent_weak_beats: bool = False   # Whether to also add rests on weak beats
-    
-    def __post_init__(self):
-        """Validate configuration."""
-        if self.rest_positions is None:
-            self.rest_positions = []
-        for pos in self.rest_positions:
-            if not 0 <= pos < STEPS_PER_BAR:
-                raise ValueError(f"Rest positions must be between 0 and {STEPS_PER_BAR-1}")
-
-@dataclass
-class PhraseConfig(BaseRestConfig):
-    """Configuration for phrase-end rest patterns."""
-    phrase_length: int = 16       # Length of each phrase in steps
-    rest_length: int = 1          # Length of rest at phrase end in steps
-    variable_length: bool = False  # Whether phrase length can vary
-    
-    def __post_init__(self):
-        """Validate configuration."""
-        if not MIN_PATTERN_LENGTH <= self.phrase_length <= MAX_PATTERN_LENGTH:
-            raise ValueError(f"phrase_length must be between {MIN_PATTERN_LENGTH} and {MAX_PATTERN_LENGTH}")
-        if self.rest_length < 1:
-            raise ValueError("rest_length must be positive")
-        if self.rest_length >= self.phrase_length:
-            raise ValueError("rest_length must be less than phrase_length") 
+from typing import Dict
 
 @dataclass
 class RestPatternConfig:
-    """Main configuration class for rest pattern generation."""
-    pattern_type: RestPatternType = RestPatternType.FIXED
-    fixed_config: FixedPatternConfig = None
-    probability_config: ProbabilityConfig = None
-    musical_pos_config: MusicalPosConfig = None
-    phrase_config: PhraseConfig = None
+    """Configuration for rest pattern generation."""
+    enabled: bool = False
+    steps_between_rests: int = 4  # Insert rest every N steps
     
-    def __post_init__(self):
-        """Initialize and validate configuration."""
-        # Initialize configs with defaults if not provided
-        if self.fixed_config is None:
-            self.fixed_config = FixedPatternConfig()
-        if self.probability_config is None:
-            self.probability_config = ProbabilityConfig()
-        if self.musical_pos_config is None:
-            self.musical_pos_config = MusicalPosConfig()
-        if self.phrase_config is None:
-            self.phrase_config = PhraseConfig()
-            
-        # Ensure only one config is enabled
-        enabled_configs = []
-        if self.fixed_config.enabled:
-            enabled_configs.append("fixed")
-        if self.probability_config.enabled:
-            enabled_configs.append("probability")
-        if self.musical_pos_config.enabled:
-            enabled_configs.append("musical_pos")
-        if self.phrase_config.enabled:
-            enabled_configs.append("phrase")
-            
-        if len(enabled_configs) > 1:
-            raise ValueError(f"Only one rest pattern config can be enabled. Found: {enabled_configs}")
-            
-    def get_active_config(self) -> Optional[BaseRestConfig]:
-        """Get the currently active configuration based on pattern_type."""
-        config_map = {
-            RestPatternType.FIXED: self.fixed_config,
-            RestPatternType.PROBABILITY: self.probability_config,
-            RestPatternType.MUSICAL_POS: self.musical_pos_config,
-            RestPatternType.PHRASE: self.phrase_config
-        }
-        return config_map.get(self.pattern_type)
-        
     @classmethod
-    def from_dict(cls, config_dict: dict) -> 'RestPatternConfig':
-        """Create a RestPatternConfig from a dictionary."""
-        pattern_type = RestPatternType[config_dict.get('pattern_type', 'FIXED')]
-        
-        # Create specific config based on pattern type
-        config_classes = {
-            RestPatternType.FIXED: FixedPatternConfig,
-            RestPatternType.PROBABILITY: ProbabilityConfig,
-            RestPatternType.MUSICAL_POS: MusicalPosConfig,
-            RestPatternType.PHRASE: PhraseConfig
-        }
-        
-        specific_config = config_dict.get(f"{pattern_type.lower()}_config", {})
-        active_config = config_classes[pattern_type](**specific_config)
-        active_config.enabled = True
-        
-        # Create main config with only the active specific config
-        kwargs = {
-            'pattern_type': pattern_type,
-            f"{pattern_type.lower()}_config": active_config
-        }
-        
-        return cls(**kwargs) 
+    def from_dict(cls, config_dict: Dict) -> 'RestPatternConfig':
+        """Create a RestPatternConfig instance from a dictionary."""
+        return cls(
+            enabled=config_dict.get('enabled', False),
+            steps_between_rests=config_dict.get('steps_between_rests', 4)
+        ) 

--- a/rest_patterns/rest_config.py
+++ b/rest_patterns/rest_config.py
@@ -1,0 +1,137 @@
+"""
+Configuration classes for rest pattern generation.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, List
+from .types import RestPatternType, MIN_PATTERN_LENGTH, MAX_PATTERN_LENGTH
+
+@dataclass
+class BaseRestConfig:
+    """Base configuration for all rest patterns."""
+    enabled: bool = False
+    maintain_rhythm: bool = True  # If True, maintain original timing when inserting rests
+
+@dataclass
+class FixedPatternConfig(BaseRestConfig):
+    """Configuration for fixed-interval rest patterns."""
+    steps_between_rests: int = 4  # Insert rest every N steps
+    pattern_shift: bool = False    # Whether pattern position shifts over time
+    
+    def __post_init__(self):
+        """Validate configuration."""
+        if not MIN_PATTERN_LENGTH <= self.steps_between_rests <= MAX_PATTERN_LENGTH:
+            raise ValueError(f"steps_between_rests must be between {MIN_PATTERN_LENGTH} and {MAX_PATTERN_LENGTH}")
+
+@dataclass
+class ProbabilityConfig(BaseRestConfig):
+    """Configuration for probability-based rest patterns."""
+    rest_chance: float = 0.15     # Probability of rest per step (0-1)
+    beat_weight: float = 1.5      # How much to favor strong beats for rests
+    
+    def __post_init__(self):
+        """Validate configuration."""
+        if not 0 <= self.rest_chance <= 1:
+            raise ValueError("rest_chance must be between 0 and 1")
+        if self.beat_weight < 0:
+            raise ValueError("beat_weight must be non-negative")
+
+@dataclass
+class MusicalPosConfig(BaseRestConfig):
+    """Configuration for musical-position-based rest patterns."""
+    rest_positions: List[int] = None  # List of step positions to rest (0-15 in 16-step bar)
+    accent_weak_beats: bool = False   # Whether to also add rests on weak beats
+    
+    def __post_init__(self):
+        """Validate configuration."""
+        if self.rest_positions is None:
+            self.rest_positions = []
+        for pos in self.rest_positions:
+            if not 0 <= pos < STEPS_PER_BAR:
+                raise ValueError(f"Rest positions must be between 0 and {STEPS_PER_BAR-1}")
+
+@dataclass
+class PhraseConfig(BaseRestConfig):
+    """Configuration for phrase-end rest patterns."""
+    phrase_length: int = 16       # Length of each phrase in steps
+    rest_length: int = 1          # Length of rest at phrase end in steps
+    variable_length: bool = False  # Whether phrase length can vary
+    
+    def __post_init__(self):
+        """Validate configuration."""
+        if not MIN_PATTERN_LENGTH <= self.phrase_length <= MAX_PATTERN_LENGTH:
+            raise ValueError(f"phrase_length must be between {MIN_PATTERN_LENGTH} and {MAX_PATTERN_LENGTH}")
+        if self.rest_length < 1:
+            raise ValueError("rest_length must be positive")
+        if self.rest_length >= self.phrase_length:
+            raise ValueError("rest_length must be less than phrase_length") 
+
+@dataclass
+class RestPatternConfig:
+    """Main configuration class for rest pattern generation."""
+    pattern_type: RestPatternType = RestPatternType.FIXED
+    fixed_config: FixedPatternConfig = None
+    probability_config: ProbabilityConfig = None
+    musical_pos_config: MusicalPosConfig = None
+    phrase_config: PhraseConfig = None
+    
+    def __post_init__(self):
+        """Initialize and validate configuration."""
+        # Initialize configs with defaults if not provided
+        if self.fixed_config is None:
+            self.fixed_config = FixedPatternConfig()
+        if self.probability_config is None:
+            self.probability_config = ProbabilityConfig()
+        if self.musical_pos_config is None:
+            self.musical_pos_config = MusicalPosConfig()
+        if self.phrase_config is None:
+            self.phrase_config = PhraseConfig()
+            
+        # Ensure only one config is enabled
+        enabled_configs = []
+        if self.fixed_config.enabled:
+            enabled_configs.append("fixed")
+        if self.probability_config.enabled:
+            enabled_configs.append("probability")
+        if self.musical_pos_config.enabled:
+            enabled_configs.append("musical_pos")
+        if self.phrase_config.enabled:
+            enabled_configs.append("phrase")
+            
+        if len(enabled_configs) > 1:
+            raise ValueError(f"Only one rest pattern config can be enabled. Found: {enabled_configs}")
+            
+    def get_active_config(self) -> Optional[BaseRestConfig]:
+        """Get the currently active configuration based on pattern_type."""
+        config_map = {
+            RestPatternType.FIXED: self.fixed_config,
+            RestPatternType.PROBABILITY: self.probability_config,
+            RestPatternType.MUSICAL_POS: self.musical_pos_config,
+            RestPatternType.PHRASE: self.phrase_config
+        }
+        return config_map.get(self.pattern_type)
+        
+    @classmethod
+    def from_dict(cls, config_dict: dict) -> 'RestPatternConfig':
+        """Create a RestPatternConfig from a dictionary."""
+        pattern_type = RestPatternType[config_dict.get('pattern_type', 'FIXED')]
+        
+        # Create specific config based on pattern type
+        config_classes = {
+            RestPatternType.FIXED: FixedPatternConfig,
+            RestPatternType.PROBABILITY: ProbabilityConfig,
+            RestPatternType.MUSICAL_POS: MusicalPosConfig,
+            RestPatternType.PHRASE: PhraseConfig
+        }
+        
+        specific_config = config_dict.get(f"{pattern_type.lower()}_config", {})
+        active_config = config_classes[pattern_type](**specific_config)
+        active_config.enabled = True
+        
+        # Create main config with only the active specific config
+        kwargs = {
+            'pattern_type': pattern_type,
+            f"{pattern_type.lower()}_config": active_config
+        }
+        
+        return cls(**kwargs) 

--- a/rest_patterns/rest_processor.py
+++ b/rest_patterns/rest_processor.py
@@ -1,0 +1,88 @@
+"""
+Rest pattern processor effect for MIDI sequences.
+"""
+
+from typing import List, Union, Tuple, Dict
+from .rest_config import RestPatternConfig
+from ..effects_base import MidiEffect, EffectConfiguration, EffectType, MidiInstruction
+
+class RestPatternConfiguration(EffectConfiguration):
+    """Configuration for rest pattern effect."""
+    def __init__(self, config_dict: Dict):
+        super().__init__()
+        self.rest_config = RestPatternConfig.from_dict(config_dict)
+        
+    def __post_init__(self):
+        """Set effect type and priority."""
+        self.effect_type = EffectType.SEQUENCE_PROCESSOR
+        self.priority = 100  # Run before other effects
+
+class RestPatternEffect(MidiEffect):
+    """Effect that applies rest patterns to a sequence."""
+    
+    def __init__(self, config: RestPatternConfiguration):
+        super().__init__(config)
+        self.rest_config = config.rest_config
+        
+    def _validate_configuration(self) -> None:
+        """Validate the configuration."""
+        if not isinstance(self.config, RestPatternConfiguration):
+            raise ValueError("Configuration must be a RestPatternConfiguration")
+    
+    def _process_note_impl(self, ctx: Dict) -> Dict:
+        """Not used for rest patterns."""
+        return ctx
+    
+    def _process_sequence_impl(self, 
+                             events: List[Union[MidiInstruction, Tuple]], 
+                             options: Dict) -> List[Union[MidiInstruction, Tuple]]:
+        """Apply rest pattern to the sequence."""
+        if not events or not self.rest_config.enabled:
+            return events
+            
+        # Get sequence parameters
+        ticks_per_beat = options.get('ticks_per_beat', 480)
+        ticks_per_step = ticks_per_beat // 4  # 16th notes
+        arp_steps = options.get('arp_steps', 8)  # Get the arp cycle length
+        
+        print(f"\n[DEBUG] Rest Pattern Processing:")
+        print(f"[DEBUG] Steps between rests: {self.rest_config.steps_between_rests}")
+        print(f"[DEBUG] Arp steps: {arp_steps}")
+        print(f"[DEBUG] Ticks per step: {ticks_per_step}")
+        
+        # First pass: identify which notes to remove
+        notes_to_remove = set()  # Set of (note_number, channel) tuples
+        
+        for event in events:
+            if isinstance(event, tuple) and event[0] == 'note_on':
+                tick = event[1]
+                current_step = tick // ticks_per_step
+                
+                # Calculate position within arp cycle
+                step_in_cycle = current_step % arp_steps
+                
+                # If this step should be a rest within the cycle
+                if step_in_cycle % self.rest_config.steps_between_rests == self.rest_config.steps_between_rests - 1:
+                    note_number = event[2]
+                    channel = event[4]
+                    notes_to_remove.add((note_number, channel))
+                    print(f"[DEBUG] Marking note {note_number} at step {current_step} (cycle pos {step_in_cycle}) for rest")
+        
+        # Second pass: remove both note_on and corresponding note_off events
+        processed_events = []
+        
+        for event in events:
+            if isinstance(event, tuple):
+                if event[0] in ('note_on', 'note_off'):
+                    note_number = event[2]
+                    channel = event[4]
+                    if (note_number, channel) in notes_to_remove:
+                        tick = event[1]
+                        current_step = tick // ticks_per_step
+                        step_in_cycle = current_step % arp_steps
+                        print(f"[DEBUG] Removing {event[0]} event for note {note_number} at step {current_step} (cycle pos {step_in_cycle})")
+                        continue
+                
+                processed_events.append(event)
+        
+        return processed_events 

--- a/rest_patterns/types.py
+++ b/rest_patterns/types.py
@@ -1,30 +1,6 @@
 """
-Type definitions and constants for rest pattern processing.
+Core types for rest pattern processing.
 """
 
-from enum import Enum
-from typing import List, Union, Tuple
-from dataclasses import dataclass
-
-class RestPatternType(Enum):
-    """Types of rest patterns available."""
-    FIXED = "fixed"          # Regular interval patterns
-    PROBABILITY = "prob"     # Random probability based
-    MUSICAL_POS = "pos"      # Based on musical position
-    PHRASE = "phrase"        # Phrase-end based
-
-# Type aliases for clarity
-RestPattern = List[bool]     # True = rest, False = play
-Tick = int                   # MIDI tick position
-Step = int                   # Step number in sequence
-
-# Constants for musical timing
-TICKS_PER_QUARTER = 480     # Standard MIDI resolution
-STEPS_PER_BAR = 16          # Default steps per bar (16th notes)
-MIN_PATTERN_LENGTH = 1      # Minimum pattern length
-MAX_PATTERN_LENGTH = 32     # Maximum pattern length
-
-# Default values
-DEFAULT_REST_ENABLED = False
-DEFAULT_PATTERN_TYPE = RestPatternType.FIXED
-DEFAULT_MAINTAIN_RHYTHM = True  # Whether to maintain timing when inserting rests 
+TICKS_PER_QUARTER = 480
+STEPS_PER_BAR = 16  # 16th notes per bar

--- a/rest_patterns/types.py
+++ b/rest_patterns/types.py
@@ -1,0 +1,30 @@
+"""
+Type definitions and constants for rest pattern processing.
+"""
+
+from enum import Enum
+from typing import List, Union, Tuple
+from dataclasses import dataclass
+
+class RestPatternType(Enum):
+    """Types of rest patterns available."""
+    FIXED = "fixed"          # Regular interval patterns
+    PROBABILITY = "prob"     # Random probability based
+    MUSICAL_POS = "pos"      # Based on musical position
+    PHRASE = "phrase"        # Phrase-end based
+
+# Type aliases for clarity
+RestPattern = List[bool]     # True = rest, False = play
+Tick = int                   # MIDI tick position
+Step = int                   # Step number in sequence
+
+# Constants for musical timing
+TICKS_PER_QUARTER = 480     # Standard MIDI resolution
+STEPS_PER_BAR = 16          # Default steps per bar (16th notes)
+MIN_PATTERN_LENGTH = 1      # Minimum pattern length
+MAX_PATTERN_LENGTH = 32     # Maximum pattern length
+
+# Default values
+DEFAULT_REST_ENABLED = False
+DEFAULT_PATTERN_TYPE = RestPatternType.FIXED
+DEFAULT_MAINTAIN_RHYTHM = True  # Whether to maintain timing when inserting rests 


### PR DESCRIPTION
• Pattern Repetition Control

- Added a new repeat_pattern boolean option in __main__.py
- Only prompted when user selects 8 or 4 steps (not for 16 steps)
- Allows user to choose between:
- Repeating the pattern using 16th notes
- Using longer notes (8th or quarter notes)

• Note Length Calculation

- Added logic to determine note lengths based on two factors:
- Number of steps (16, 8, or 4)
- Pattern repetition setting
- When arp_steps == 16 OR repeat_pattern == True:
- Uses 16th notes (steps_per_note = 1)
- Pattern repeats multiple times per bar
- When arp_steps < 16 AND repeat_pattern == False:
- Uses longer notes (8th or quarter notes)
- Pattern plays once per bar with proper note lengths

• Pattern Generation

- Added repeats_per_bar calculation:
- For 16th notes: steps_per_bar // arp_steps repeats
- For longer notes: just 1 repeat
- Modified note generation to handle both cases:
- 16th notes: directly append notes
- Longer notes: append note followed by appropriate number of None values

• Debug Information

- Added more detailed debug output:
  - Steps per bar (always 16)
  - Arp steps (16, 8, or 4)
  - Steps per note (1, 2, or 4)
  - Pattern repeats per bar
  - Note length being used (16th, 8th, or quarter)